### PR TITLE
Cleanup import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # borsh-go
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/near/borsh-go.svg)](https://pkg.go.dev/github.com/near/borsh-go)
+
 **borsh-go** is an implementation of the [Borsh] binary serialization format for Go
 projects.
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ defining `struct` and go.
 package demo
 
 import (
-	"github.com/ouromoros/borsh-go"
 	"log"
 	"reflect"
 	"testing"
+
+	"github.com/near/borsh-go"
 )
 
 type A struct {

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,9 +1,10 @@
 package borsh_test
 
 import (
-	"github.com/ouromoros/borsh-go"
 	"math/rand"
 	"testing"
+
+	"github.com/near/borsh-go"
 )
 
 type B struct {

--- a/borsh.go
+++ b/borsh.go
@@ -256,7 +256,7 @@ func deserializeStruct(t reflect.Type, r io.Reader) (interface{}, error) {
 
 // Serialize `s` into bytes according to Borsh's specification(https://borsh.io/).
 //
-// The type mapping can be found at https://github.com/ouromoros/borsh-go.
+// The type mapping can be found at https://github.com/near/borsh-go.
 func Serialize(s interface{}) ([]byte, error) {
 	result := new(bytes.Buffer)
 

--- a/example_test.go
+++ b/example_test.go
@@ -2,9 +2,10 @@ package borsh_test
 
 import (
 	"bytes"
-	"github.com/ouromoros/borsh-go"
 	"log"
 	"strings"
+
+	"github.com/near/borsh-go"
 )
 
 type A struct {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,10 +1,11 @@
 package borsh_test
 
 import (
-	"github.com/ouromoros/borsh-go"
 	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/near/borsh-go"
 )
 
 func TestFuzz(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ouromoros/borsh-go
+module github.com/near/borsh-go
 
 go 1.15


### PR DESCRIPTION
As it stands this package cannot be imported without Go complaining about the mismatch between the repository path and the path defined in `go.mod`.

Should be tagged as version `0.2.1` after merge.