### PR TITLE
feat: add custom type support for int and uint

### DIFF
--- a/borsh.go
+++ b/borsh.go
@@ -283,7 +283,7 @@ func deserializeStruct(t reflect.Type, r io.Reader) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		v.Field(i).Set(reflect.ValueOf(fv))
+		v.Field(i).Set(reflect.ValueOf(fv).Convert(field.Type))
 	}
 
 	return v.Interface(), nil
@@ -379,18 +379,18 @@ func serialize(v reflect.Value, b io.Writer) error {
 	var err error
 	switch v.Kind() {
 	case reflect.Int8:
-		_, err = b.Write([]byte{byte((v.Interface().(int8)))})
+		_, err = b.Write([]byte{byte((v.Int()))})
 	case reflect.Int16:
 		tmp := make([]byte, 2)
-		binary.LittleEndian.PutUint16(tmp, uint16(v.Interface().(int16)))
+		binary.LittleEndian.PutUint16(tmp, uint16(v.Int()))
 		_, err = b.Write(tmp)
 	case reflect.Int32:
 		tmp := make([]byte, 4)
-		binary.LittleEndian.PutUint32(tmp, uint32(v.Interface().(int32)))
+		binary.LittleEndian.PutUint32(tmp, uint32(v.Int()))
 		_, err = b.Write(tmp)
 	case reflect.Int64:
 		tmp := make([]byte, 8)
-		binary.LittleEndian.PutUint64(tmp, uint64(v.Interface().(int64)))
+		binary.LittleEndian.PutUint64(tmp, uint64(v.Int()))
 		_, err = b.Write(tmp)
 	case reflect.Int:
 		tmp := make([]byte, 8)
@@ -401,11 +401,11 @@ func serialize(v reflect.Value, b io.Writer) error {
 		_, err = b.Write([]byte{byte(v.Uint())})
 	case reflect.Uint16:
 		tmp := make([]byte, 2)
-		binary.LittleEndian.PutUint16(tmp, v.Interface().(uint16))
+		binary.LittleEndian.PutUint16(tmp, uint16(v.Uint()))
 		_, err = b.Write(tmp)
 	case reflect.Uint32:
 		tmp := make([]byte, 4)
-		binary.LittleEndian.PutUint32(tmp, v.Interface().(uint32))
+		binary.LittleEndian.PutUint32(tmp, uint32(v.Uint()))
 		_, err = b.Write(tmp)
 	case reflect.Uint64, reflect.Uint:
 		tmp := make([]byte, 8)

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -360,3 +360,48 @@ func TestUint128(t *testing.T) {
 		testValue(t, tt.in)
 	}
 }
+
+type Myu8 uint8
+type Myu16 uint16
+type Myu32 uint32
+type Myu64 uint64
+type Myi8 int8
+type Myi16 int16
+type Myi32 int32
+type Myi64 int64
+
+type CustomType struct {
+	U8  Myu8
+	U16 Myu16
+	U32 Myu32
+	U64 Myu64
+	I8  Myi8
+	I16 Myi16
+	I32 Myi32
+	I64 Myi64
+}
+
+func TestCustomType(t *testing.T) {
+	x := CustomType{
+		U8:  1,
+		U16: 2,
+		U32: 3,
+		U64: 4,
+		I8:  5,
+		I16: 6,
+		I32: 7,
+		I64: 8,
+	}
+	data, err := Serialize(x)
+	if err != nil {
+		t.Error(err)
+	}
+	y := new(CustomType)
+	err = Deserialize(y, data)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(x, *y) {
+		t.Error(x, y)
+	}
+}


### PR DESCRIPTION
I found that It will panic when I serialize and deserialize including custom type. I add some support for these types:
- uint8
- uint16
- uint32
- uint64
- int8
- int16
- int32
- int64