### PR TITLE
feat: support bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For more examples of usage, refer to `borsh_test.go`.
 
 Borsh                 | Go           |  Description
 --------------------- | -------------- |--------
+`bool`		      | `bool`	       |
 `u8` integer          | `uint8`        |
 `u16` integer         | `uint16`       |
 `u32` integer         | `uint32`       |

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ For more examples of usage, refer to `borsh_test.go`.
 
 Borsh                 | Go           |  Description
 --------------------- | -------------- |--------
-`u8` integer          | `uint8`        | 
+`u8` integer          | `uint8`        |
 `u16` integer         | `uint16`       |
 `u32` integer         | `uint32`       |
 `u64` integer         | `uint64`       |
 `u128` integer        | `big.Int`  |
-`i8` integer          | `int8`        | 
+`i8` integer          | `int8`        |
 `i16` integer         | `int16`       |
 `i32` integer         | `int32`       |
 `i64` integer         | `int64`       |

--- a/borsh.go
+++ b/borsh.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"math/big"
@@ -51,6 +52,19 @@ func deserialize(t reflect.Type, r io.Reader) (interface{}, error) {
 	}
 
 	switch t.Kind() {
+	case reflect.Bool:
+		tmp, err := read(r, 1)
+		if err != nil {
+			return nil, err
+		}
+		switch tmp[0] {
+		case 0:
+			return false, nil
+		case 1:
+			return true, nil
+		default:
+			return nil, fmt.Errorf("expected bool is 0 or 1, got %v", tmp[0])
+		}
 	case reflect.Int8:
 		tmp, err := read(r, 1)
 		if err != nil {
@@ -378,6 +392,12 @@ func serializeUint128(v reflect.Value, b io.Writer) error {
 func serialize(v reflect.Value, b io.Writer) error {
 	var err error
 	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			_, err = b.Write([]byte{1})
+		} else {
+			_, err = b.Write([]byte{0})
+		}
 	case reflect.Int8:
 		_, err = b.Write([]byte{byte((v.Int()))})
 	case reflect.Int16:

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -405,3 +405,27 @@ func TestCustomType(t *testing.T) {
 		t.Error(x, y)
 	}
 }
+
+type BoolStruct struct {
+	T bool
+	F bool
+}
+
+func TestBool(t *testing.T) {
+	x := BoolStruct{
+		T: true,
+		F: false,
+	}
+	data, err := Serialize(x)
+	if err != nil {
+		t.Error(err)
+	}
+	y := new(BoolStruct)
+	err = Deserialize(y, data)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(x, *y) {
+		t.Error(x, y)
+	}
+}


### PR DESCRIPTION
I found that the specification in https://borsh.io/ didn't write `bool` as a supported type
but there was a bool convert implementation in the [rust implemation](https://github.com/near/borsh-rs/blob/master/borsh/src/ser/mod.rs#L124)
so I add it into this go lib.
