### PR TITLE
Return `err` on `deserialize` failure

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -21,7 +21,7 @@ func (d *Decoder) Decode(s interface{}) error {
 	}
 	val, err := deserialize(t, d.r)
 	if err != nil {
-		return nil
+		return err
 	}
 	reflect.ValueOf(s).Elem().Set(reflect.ValueOf(val))
 	return nil


### PR DESCRIPTION
Typo makes it so errors aren't surfaced from `deserialize` in `Decoder#Decode`.