### PR TITLE
Add interface support to serialize

### DIFF
--- a/borsh.go
+++ b/borsh.go
@@ -392,6 +392,8 @@ func serializeUint128(v reflect.Value, b io.Writer) error {
 func serialize(v reflect.Value, b io.Writer) error {
 	var err error
 	switch v.Kind() {
+	case reflect.Interface:
+		return serialize(v.Elem(), b)
 	case reflect.Bool:
 		if v.Bool() {
 			_, err = b.Write([]byte{1})

--- a/borsh.go
+++ b/borsh.go
@@ -393,7 +393,7 @@ func serialize(v reflect.Value, b io.Writer) error {
 	var err error
 	switch v.Kind() {
 	case reflect.Interface:
-		return serialize(v.Elem(), b)
+		err = serialize(v.Elem(), b)
 	case reflect.Bool:
 		if v.Bool() {
 			_, err = b.Write([]byte{1})

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -496,3 +496,25 @@ func TestPointer(t *testing.T) {
 		t.Errorf("expected pointer byte to be 0")
 	}
 }
+
+func TestArrayInterface(t *testing.T) {
+	x := []interface{}{
+		1,
+		2,
+		3,
+	}
+	data, err := Serialize(x)
+	if err != nil {
+		t.Error(err)
+	}
+	y := make([]int, 3)
+	err = Deserialize(&y, data)
+	if err != nil {
+		t.Error(err)
+	}
+	for i, val := range x {
+		if !reflect.DeepEqual(val, y[i]) {
+			t.Error(i, val, y[i])
+		}
+	}
+}

--- a/borsh_test.go
+++ b/borsh_test.go
@@ -507,7 +507,7 @@ func TestArrayInterface(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	y := make([]int, 3)
+	var y []int
 	err = Deserialize(&y, data)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Currently it is impossible to serialize a []interface{} or structs with an interface{} field.  Adding support to the serialize function for the interface type.